### PR TITLE
SpecialComment highlight group for pythonCoding and pythonRun

### DIFF
--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -63,8 +63,8 @@
 "
 "    python_highlight_builtins              Highlight builtin functions and
 "                                           objects
-"      python_highlight_builtin_objs        Highlight builtin objects only
-"      python_highlight_builtin_funcs       Highlight builtin functions only
+"    python_highlight_builtin_objs          Highlight builtin objects only
+"    python_highlight_builtin_funcs         Highlight builtin functions only
 "    python_highlight_exceptions            Highlight standard exceptions
 "    python_highlight_string_formatting     Highlight % string formatting
 "    python_highlight_string_format         Highlight str.format syntax

--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -493,8 +493,8 @@ if version >= 508 || !exists("did_python_syn_inits")
 
   HiLink pythonComment          Comment
   if !s:Enabled("g:python_highlight_file_headers_as_comments")
-    HiLink pythonCoding           Special
-    HiLink pythonRun              Special
+    HiLink pythonCoding           SpecialComment
+    HiLink pythonRun              SpecialComment
   endif
   HiLink pythonTodo             Todo
 


### PR DESCRIPTION
So you can use the SpecialComment minor highlight group for pythonCoding and pythonRun lines
