### PR TITLE
else: highlighting and erroneous numbers

### DIFF
--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -153,7 +153,7 @@ syn keyword pythonStatement     lambda
 syn keyword pythonStatement     with
 syn keyword pythonStatement     def class nextgroup=pythonFunction skipwhite
 syn keyword pythonRepeat        for while
-syn keyword pythonConditional   if elif else
+syn keyword pythonConditional   if elif else else:
 syn keyword pythonImport        import
 syn keyword pythonException     try except finally
 syn keyword pythonOperator      and in is not or
@@ -365,9 +365,9 @@ else
 
   syn match   pythonNumberError	"\<\d\+\D\>" display
   syn match   pythonNumberError	"\<0\d\+\>" display
-  syn match   pythonNumber	"\<\d\>" display
-  syn match   pythonNumber	"\<[1-9]\d\+\>" display
-  syn match   pythonNumber	"\<\d\+[jJ]\>" display
+  syn match   pythonNumber	"\<\d\:\=\>" display
+  syn match   pythonNumber	"\<[1-9]\d\+\:\=\>" display
+  syn match   pythonNumber	"\<\d\+[jJ]\:\=\>" display
 
   syn match   pythonOctError	"\<0[oO]\=\o*[8-9]\d*\>" display
   syn match   pythonBinError	"\<0[bB][01]*[2-9]\d*\>" display

--- a/test.py
+++ b/test.py
@@ -55,7 +55,7 @@ RuntimeWarning FutureWarning ImportWarning UnicodeWarning
 # Numbers
 
 0 1 2 9 10 0x1f .3 12.34 0j 0j 34.2E-3 0b10 0o77 1023434 0x0
-
+0:
 # Erroneous numbers
 
 077 100L 0xfffffffL 0L 08 0xk 0x  0b102 0o78 0o123LaB
@@ -128,9 +128,9 @@ $ ? 6xav
 
 # Trailing space errors.
 
-    	
-    break	    
-"""  	
-   	 
-    test    	
-"""  	
+
+    break
+"""
+
+    test
+"""


### PR DESCRIPTION
else: is now highlighted as a pythonConditional keyword and numbers followed by colons are no longer seen ass erroneous numbers, so conditionals can conform to PEP8, e.g. if x == 0:
