### PR TITLE
Add highlight of classes

### DIFF
--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -197,7 +197,7 @@ syn keyword pythonTodo		TODO FIXME XXX contained
 " Classes
 "
 
-syn match pythonClass       "\(import \)\@<!\<[A-Z][a-zA-Z]*" display
+syn match pythonClass       "\(import \)\@<!\<[A-Z][a-zA-Z]*\>" display
 
 "
 " Errors


### PR DESCRIPTION
This gives a highlight to variables that are UpperCamelCase, e.g. Python
classes.
