### PR TITLE
Correct highlighting async function names in Python 3.5

### DIFF
--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -176,7 +176,7 @@ else
   syn keyword pythonBoolean     True False
   syn match   pythonFunction    "\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*" display contained
   syn keyword pythonStatement   await
-  syn match   pythonStatement   "\<async\s\+def\>" display
+  syn match   pythonStatement   "\<async\s\+def\>" nextgroup=pythonFunction skipwhite
   syn match   pythonStatement   "\<async\s\+with\>" display
   syn match   pythonStatement   "\<async\s\+for\>" display
   syn match   pythonStatement   "\<async\s\+with\>" display


### PR DESCRIPTION
The pull request version of #36.