### PR TITLE
Highlight punctuation that does not fall into any syntax group

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -95,6 +95,8 @@ highlighting modes:
 Options used by the script
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+``python_highlight_default_punctuation``
+  Highlight punctuation that does not fall into any syntax group
 ``python_highlight_builtins``
   Highlight builtin functions and objects
 ``python_highlight_builtin_objs``

--- a/syntax.txt
+++ b/syntax.txt
@@ -32,7 +32,9 @@ highlighting modes:
 <
 Options used by the script
 
-  Highlight builtin functions and objects >
+  Highlight punctuation that does not fall into any syntax group >
+    :let python_highlight_default_punctuation
+<  Highlight builtin functions and objects >
     :let python_highlight_builtins = 1
 <  Highlight builtin objects only >
     :let python_highlight_builtin_objs = 1

--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -66,6 +66,8 @@
 " Option names used by the script
 " -------------------------------
 "
+"    python_highlight_default_punctuation   Highlight punctuation that does not
+"                                           fall into any syntax group
 "    python_highlight_builtins              Highlight builtin functions and
 "                                           objects
 "      python_highlight_builtin_objs        Highlight builtin objects only
@@ -131,6 +133,7 @@ endfunction
 call s:EnableByDefault("g:python_slow_sync")
 
 if s:Enabled("g:python_highlight_all")
+  call s:EnableByDefault("g:python_highlight_default_punctuation")
   call s:EnableByDefault("g:python_highlight_builtins")
   if s:Enabled("g:python_highlight_builtins")
     call s:EnableByDefault("g:python_highlight_builtin_objs")
@@ -144,6 +147,14 @@ if s:Enabled("g:python_highlight_all")
   call s:EnableByDefault("g:python_highlight_space_errors")
   call s:EnableByDefault("g:python_highlight_doctests")
   call s:EnableByDefault("g:python_print_as_function")
+endif
+
+"
+" Default punctuation
+"
+
+if s:Enabled("g:python_highlight_default_punctuation")
+  syn match pythonPunctuation "[^A-Za-z0-9_]"
 endif
 
 "
@@ -494,6 +505,8 @@ if version >= 508 || !exists("did_python_syn_inits")
   else
     command -nargs=+ HiLink hi def link <args>
   endif
+
+  HiLink pythonPunctuation      Special
 
   HiLink pythonStatement        Statement
   HiLink pythonImport           Include


### PR DESCRIPTION
Hi, I was wondering if you were interested in merging this patch: it creates a group (`pythonPunctuation`, disabled by default) for generic punctuation characters that is tested before any other group, so that only the text outside of any group is affected.
I'm not sure if I'd also be required to edit `CHANGES.txt` or the files under `folding-ideas/`.
