### PR TITLE
narrow decorator match to exclude matrix multiplication

### DIFF
--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -190,7 +190,7 @@ endif
 " Decorators (new in Python 2.4)
 "
 
-syn match   pythonDecorator	"\(^\s*\)\@<=@" display nextgroup=pythonDottedName skipwhite
+syn match   pythonDecorator	"^\s*\zs@" display nextgroup=pythonDottedName skipwhite
 if s:Python2Syntax()
   syn match   pythonDottedName "[a-zA-Z_][a-zA-Z0-9_]*\%(\.[a-zA-Z_][a-zA-Z0-9_]*\)*" display contained
 else

--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -190,7 +190,7 @@ endif
 " Decorators (new in Python 2.4)
 "
 
-syn match   pythonDecorator	"@" display nextgroup=pythonDottedName skipwhite
+syn match   pythonDecorator	"\(^\s*\)\@<=@" display nextgroup=pythonDottedName skipwhite
 if s:Python2Syntax()
   syn match   pythonDottedName "[a-zA-Z_][a-zA-Z0-9_]*\%(\.[a-zA-Z_][a-zA-Z0-9_]*\)*" display contained
 else


### PR DESCRIPTION
Fixes #46. "@" in decorator definition always has to start a line. "@" as an inflix operator has to be always proceeded with something. This change distinguishes these two cases.
