### PR TITLE
Allow None to be highlighted differently

### DIFF
--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -176,7 +176,8 @@ if s:Python2Syntax()
   syn keyword pythonImport      as
   syn match   pythonFunction    "[a-zA-Z_][a-zA-Z0-9_]*" display contained
 else
-  syn keyword pythonStatement   as nonlocal None
+  syn keyword pythonStatement   as nonlocal
+  syn keyword pythonNone        None
   syn match   pythonStatement   "\<yield\s\+from\>" display
   syn keyword pythonBoolean     True False
   syn match   pythonFunction    "\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*" display contained
@@ -399,7 +400,7 @@ syn match   pythonFloat		"\<\d\+\.\d*\%([eE][+-]\=\d\+\)\=[jJ]\=" display
 
 if s:Enabled("g:python_highlight_builtin_objs")
   if s:Python2Syntax()
-    syn keyword pythonBuiltinObj	None
+    syn keyword pythonNone	        None
     syn keyword pythonBoolean		True False
   endif
   syn keyword pythonBuiltinObj	Ellipsis NotImplemented
@@ -529,6 +530,7 @@ if version >= 508 || !exists("did_python_syn_inits")
     HiLink pythonUniRawString       String
     HiLink pythonUniRawEscape       Special
     HiLink pythonUniRawEscapeError  Error
+    HiLink pythonNone               pythonBuiltinObj
   else
     HiLink pythonBytes              String
     HiLink pythonRawBytes           String
@@ -536,6 +538,7 @@ if version >= 508 || !exists("did_python_syn_inits")
     HiLink pythonBytesError         Error
     HiLink pythonBytesEscape        Special
     HiLink pythonBytesEscapeError   Error
+    HiLink pythonNone               pythonStatement
   endif
 
   HiLink pythonStrFormatting    Special


### PR DESCRIPTION
Creates a new highlighting group (`pythonNone`) so that, in color schemes and elsewhere, `None` can be highlighted differently than other statements. There is no change in behavior, unless the user chooses to re-highlight `pythonNone`.

Provides a workaround for #33.

Addresses the same concern as #53, but in a more general manner.
