### PR TITLE
Add support for Python 3.6 f-string literal, underscore in numbers, and Python 3.5 type annotations

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,8 @@ Features
 
 Changes from the original ``python.vim`` are:
 
-- Added support for Python 3 syntax highlighting
+- Added support for Python 3.5/3.6+ syntax highlighting, including f-string
+  literals and type annotations.
 - Added ``:Python2Syntax`` and ``:Python3Syntax`` commands which allow to
   switch between Python 2 and Python 3 syntaxes respectively without
   reloads/restarts
@@ -101,6 +102,8 @@ Options used by the script
   Highlight builtin objects only
 ``python_highlight_builtin_funcs``
   Highlight builtin functions only
+``python_highlight_type_annotations``
+  Highlight Python 3.5+ type annotations
 ``python_highlight_exceptions``
   Highlight standard exceptions
 ``python_highlight_string_formatting``

--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -152,7 +152,10 @@ endif
 "
 
 syn keyword pythonStatement     break continue del
-syn keyword pythonStatement     exec return
+if s:Python2Syntax()
+  syn keyword pythonStatement     exec
+endif
+syn keyword pythonStatement     return
 syn keyword pythonStatement     pass raise
 syn keyword pythonStatement     global assert
 syn keyword pythonStatement     with

--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -173,11 +173,12 @@ syn match pythonLambdaExpr   "\<lambda[^:]*:"he=s+6 contains=@pythonExpression n
 
 syn region pythonDictSetExpr matchgroup=pythonDictSetExpr start='{' end='}' contains=@pythonExpression
 syn region pythonListSliceExpr matchgroup=pythonListSliceExpr start='\[' end='\]' contains=@pythonExpression
-syn region pythonFuncArgs    matchgroup=pythonFuncArgs    start='(' end=')' contained contains=pythonTypeAnno,@pythonExpression
+syn region pythonFuncArgs    matchgroup=pythonFuncArgs    start='(' end=')' contained contains=@pythonTypeExpression,@pythonExpression
 
 if !s:Python2Syntax()
   if s:Enabled("g:python_highlight_type_annotations")
-    syn match pythonTypeAnno @:\s*['"]\?\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*\%(\.\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*\)*['"]\?@hs=s+1 display contained contains=pythonType,pythonString nextgroup=pythonTypeArgs
+    syn match pythonTypeAnno @:\s*['"]\?\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*\%(\.\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*\)*['"]\?@hs=s+1 display contained contains=pythonType,pythonString nextgroup=pythonTypeUnion,pythonTypeArgs
+    syn match pythonTypeUnion @\s*|\s*['"]\?\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*\%(\.\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*\)*['"]\?@ display contained contains=pythonType,pythonString nextgroup=pythonTypeUnion
     syn match pythonTypeAnnoReturn @->\s*['"]\?\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*\%(\.\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*\)*['"]\?@ display contains=pythonType,pythonString nextgroup=pythonTypeArgs
     syn region pythonTypeArgs matchgroup=pythonTypeArgs start='\[' end='\]' display contained contains=pythonType,pythonString,pythonTypeArgs
     syn keyword pythonType Any AnyStr Callable ClassVar Tuple Union Optional Type TypeVar None contained
@@ -208,6 +209,8 @@ else
   syn match   pythonStatement   "\<async\s\+with\>" display
   syn match   pythonStatement   "\<async\s\+for\>" display
 endif
+
+syn cluster pythonTypeExpression contains=pythonTypeAnno,pythonTypeUnion,pythonTypeArgs
 
 syn cluster pythonExpression contains=
             \ pythonFuncArgs,
@@ -641,6 +644,7 @@ if version >= 508 || !exists("did_python_syn_inits")
   HiLink pythonExClass          Structure
 
   HiLink pythonTypeAnno         Optional
+  HiLink pythonTypeUnion        Optional
   HiLink pythonTypeAnnoReturn   Optional
   HiLink pythonTypeArgs         Optional
   HiLink pythonType             Special

--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -190,7 +190,7 @@ endif
 " Decorators (new in Python 2.4)
 "
 
-syn match   pythonDecorator	"\(^\s*\)\@<=@" display nextgroup=pythonDottedName skipwhite
+syn match   pythonDecorator	"^\s*\zs@" display nextgroup=pythonDottedName skipwhite
 if s:Python2Syntax()
   syn match   pythonDottedName "[a-zA-Z_][a-zA-Z0-9_]*\%(\.[a-zA-Z_][a-zA-Z0-9_]*\)*" display contained
 else

--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -165,8 +165,7 @@ syn keyword pythonImport        import
 syn match   pythonIdentifier    "\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*" nextgroup=pythonFuncArgs,pythonTypeAnno display
 syn keyword pythonException     try except finally
 syn keyword pythonOperator      and in is not or
-syn match pythonLambdaExpr   "\<lambda[^:]*:"he=s+6 display nextgroup=@pythonExpression
-"syn keyword pythonStatement     lambda
+syn match pythonLambdaExpr   "\<lambda[^:]*:"he=s+6 display contains=@pythonExpression nextgroup=@pythonExpression
 
 syn region pythonDictSetExpr matchgroup=pythonDictSetExpr start='{' end='}' contains=@pythonExpression
 syn region pythonListSliceExpr matchgroup=pythonListSliceExpr start='\[' end='\]' contains=@pythonExpression
@@ -336,10 +335,10 @@ else
   syn region pythonString   start=+"""+ end=+"""+ keepend contains=pythonBytesEscape,pythonBytesEscapeError,pythonUniEscape,pythonUniEscapeError,pythonDocTest2,pythonSpaceError,@Spell
   syn region pythonString   start=+'''+ end=+'''+ keepend contains=pythonBytesEscape,pythonBytesEscapeError,pythonUniEscape,pythonUniEscapeError,pythonDocTest,pythonSpaceError,@Spell
 
-  syn region pythonFString   start=+[fF]'+ skip=+\\\\\|\\'\|\\$+ excludenl end=+'+ end=+$+ keepend contains=pythonBytesEscape,pythonBytesEscapeError,pythonUniEscape,pythonUniEscapeError,@Spell
-  syn region pythonFString   start=+[fF]"+ skip=+\\\\\|\\"\|\\$+ excludenl end=+"+ end=+$+ keepend contains=pythonBytesEscape,pythonBytesEscapeError,pythonUniEscape,pythonUniEscapeError,@Spell
-  syn region pythonFString   start=+[fF]"""+ end=+"""+ keepend contains=pythonBytesEscape,pythonBytesEscapeError,pythonUniEscape,pythonUniEscapeError,pythonDocTest2,pythonSpaceError,@Spell
-  syn region pythonFString   start=+[fF]'''+ end=+'''+ keepend contains=pythonBytesEscape,pythonBytesEscapeError,pythonUniEscape,pythonUniEscapeError,pythonDocTest,pythonSpaceError,@Spell
+  syn region pythonFString  start=+[fF]'+ skip=+\\\\\|\\'\|\\$+ excludenl end=+'+ end=+$+ keepend contains=pythonBytesEscape,pythonBytesEscapeError,pythonUniEscape,pythonUniEscapeError,@Spell
+  syn region pythonFString  start=+[fF]"+ skip=+\\\\\|\\"\|\\$+ excludenl end=+"+ end=+$+ keepend contains=pythonBytesEscape,pythonBytesEscapeError,pythonUniEscape,pythonUniEscapeError,@Spell
+  syn region pythonFString  start=+[fF]"""+ end=+"""+ keepend contains=pythonBytesEscape,pythonBytesEscapeError,pythonUniEscape,pythonUniEscapeError,pythonDocTest2,pythonSpaceError,@Spell
+  syn region pythonFString  start=+[fF]'''+ end=+'''+ keepend contains=pythonBytesEscape,pythonBytesEscapeError,pythonUniEscape,pythonUniEscapeError,pythonDocTest,pythonSpaceError,@Spell
 endif
 
 if s:Python2Syntax()
@@ -390,9 +389,9 @@ if s:Enabled("g:python_highlight_string_format")
     syn match pythonStrFormat "{{\|}}" contained containedin=pythonString,pythonUniString,pythonUniRawString,pythonRawString
     syn match pythonStrFormat   "{\%(\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*\|\d\+\)\=\%(\.\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*\|\[\%(\d\+\|[^!:\}]\+\)\]\)*\%(![rsa]\)\=\%(:\%({\%(\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*\|\d\+\)}\|\%([^}]\=[<>=^]\)\=[ +-]\=#\=0\=\d*,\=\%(\.\d\+\)\=[bcdeEfFgGnosxX%]\=\)\=\)\=}" contained containedin=pythonString,pythonUniString,pythonUniRawString,pythonRawString
   else
-    syn match pythonStrFormat "{{\|}}" contained containedin=pythonString,pythonRawString,pythonFString
+    syn match pythonStrFormat "{{\|}}" contained containedin=pythonString,pythonRawString
     syn match pythonStrFormat "{\%(\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*\|\d\+\)\=\%(\.\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*\|\[\%(\d\+\|[^!:\}]\+\)\]\)*\%(![rsa]\)\=\%(:\%({\%(\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*\|\d\+\)}\|\%([^}]\=[<>=^]\)\=[ +-]\=#\=0\=\d*,\=\%(\.\d\+\)\=[bcdeEfFgGnosxX%]\=\)\=\)\=}" contained containedin=pythonString,pythonRawString
-    syn region pythonStrInterpRegion start="{"he=e+1,rs=e+1 end="\%(![rsa]\)\=\%(:\%({\%(\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*\|\d\+\)}\|\%([^}]\=[<>=^]\)\=[ +-]\=#\=0\=\d*,\=\%(\.\d\+\)\=[bcdeEfFgGnosxX%]\=\)\=\)\=}"hs=s-1,re=s-1 extend contained containedin=pythonFString contains=pythonStrInterpRegion,@pythonFExpression
+    syn region pythonStrInterpRegion matchgroup=pythonStrInterpRegion start="{" end="}" extend contained containedin=pythonFString contains=@pythonFExpression
   endif
 endif
 

--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -166,7 +166,7 @@ syn keyword pythonImport        import
 syn match   pythonIdentifier    "\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*" nextgroup=pythonFuncArgs,pythonTypeAnno display
 syn keyword pythonException     try except finally
 syn keyword pythonOperator      and in is not or
-syn match pythonLambdaExpr   "\<lambda[^:]*:"he=s+6 display contains=@pythonExpression nextgroup=@pythonExpression
+syn match pythonLambdaExpr   "\<lambda[^:]*:"he=s+6 contains=@pythonExpression nextgroup=@pythonExpression
 
 syn region pythonDictSetExpr matchgroup=pythonDictSetExpr start='{' end='}' contains=@pythonExpression
 syn region pythonListSliceExpr matchgroup=pythonListSliceExpr start='\[' end='\]' contains=@pythonExpression
@@ -174,8 +174,8 @@ syn region pythonFuncArgs    matchgroup=pythonFuncArgs    start='(' end=')' cont
 
 if !s:Python2Syntax()
   if s:Enabled("g:python_highlight_type_annotations")
-    syn match pythonTypeAnno @:\s*['"]\?\([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\([^[:cntrl:][:punct:][:space:]]\|_\)*['"]\?@hs=s+1 display contained contains=pythonType,pythonString nextgroup=pythonTypeArgs
-    syn match pythonTypeAnnoReturn @->\s*['"]\?\([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\([^[:cntrl:][:punct:][:space:]]\|_\)*['"]\?@ display contains=pythonType,pythonString nextgroup=pythonTypeArgs
+    syn match pythonTypeAnno @:\s*['"]\?\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*\%(\.\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*\)*['"]\?@hs=s+1 display contained contains=pythonType,pythonString nextgroup=pythonTypeArgs
+    syn match pythonTypeAnnoReturn @->\s*['"]\?\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*\%(\.\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*\)*['"]\?@ display contains=pythonType,pythonString nextgroup=pythonTypeArgs
     syn region pythonTypeArgs matchgroup=pythonTypeArgs start='\[' end='\]' display contained contains=pythonType,pythonString,pythonTypeArgs
     syn keyword pythonType Any AnyStr Callable ClassVar Tuple Union Optional Type TypeVar None contained
     syn keyword pythonType AbstractSet MutableSet Mapping MutableMapping Sequence MutableSequence ByteString Deque List contained

--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -631,6 +631,9 @@ if version >= 508 || !exists("did_python_syn_inits")
   HiLink pythonType             Special
 
   delcommand HiLink
+
+  " default style for custom highlight group (may be overriden in colors)
+  hi Optional gui=italic cterm=italic
 endif
 
 let b:current_syntax = "python"

--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -393,7 +393,7 @@ else
 
   syn match   pythonNumberError	"\<\d[_0-9]*\D\>" display
   syn match   pythonNumberError	"\<0[_0-9]\+\>" display
-  syn match   pythonNumberError	"\<\%(_[_0-9]\+\|[_0-9]\+_\)\>" display
+  syn match   pythonNumberError	"\<\d[_0-9]*_\>" display
   syn match   pythonNumber	"\<\d\>" display
   syn match   pythonNumber	"\<[1-9][_0-9]*\d\>" display
   syn match   pythonNumber	"\<\d[jJ]\>" display

--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -136,6 +136,7 @@ if s:Enabled("g:python_highlight_all")
     call s:EnableByDefault("g:python_highlight_builtin_objs")
     call s:EnableByDefault("g:python_highlight_builtin_funcs")
   endif
+  call s:EnableByDefault("g:python_highlight_type_annotations")
   call s:EnableByDefault("g:python_highlight_exceptions")
   call s:EnableByDefault("g:python_highlight_string_formatting")
   call s:EnableByDefault("g:python_highlight_string_format")
@@ -171,15 +172,19 @@ syn region pythonDictSetExpr matchgroup=pythonDictSetExpr start='{' end='}' cont
 syn region pythonListSliceExpr matchgroup=pythonListSliceExpr start='\[' end='\]' contains=@pythonExpression
 syn region pythonFuncArgs    matchgroup=pythonFuncArgs    start='(' end=')' contained contains=pythonTypeAnno,@pythonExpression
 
-syn match pythonTypeAnno ":\s*\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*"hs=s+1 display contained contains=pythonType nextgroup=pythonTypeArgs
-syn match pythonTypeAnnoReturn "->\s*\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*" display contains=pythonType nextgroup=pythonTypeArgs
-syn region pythonTypeArgs matchgroup=pythonTypeArgs start='\[' end='\]' display contained contains=pythonType,pythonTypeArgs
-syn keyword pythonType Any AnyStr Callable ClassVar Tuple Union Optional Type TypeVar None contained
-syn keyword pythonType AbstractSet MutableSet Mapping MutableMapping Sequence MutableSequence ByteString Deque List contained
-syn keyword pythonType Set FrozenSet MappingView KeysView ItemsView ValuesView Awaitable Coroutine AsyncIterable contained
-syn keyword pythonType AsyncIterator ContextManager Dict DefaultDict Generator AsyncGenerator Text NamedTuple contained
-syn keyword pythonType Iterable Iterator Reversible SupportsInt SupportsFloat SupportsAbs SupportsRound Container contained
-syn keyword pythonType Hashable Sized Collection contained
+if !s:Python2Syntax()
+  if s:Enabled("g:python_highlight_type_annotations")
+    syn match pythonTypeAnno ":\s*\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*"hs=s+1 display contained contains=pythonType nextgroup=pythonTypeArgs
+    syn match pythonTypeAnnoReturn "->\s*\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*" display contains=pythonType nextgroup=pythonTypeArgs
+    syn region pythonTypeArgs matchgroup=pythonTypeArgs start='\[' end='\]' display contained contains=pythonType,pythonTypeArgs
+    syn keyword pythonType Any AnyStr Callable ClassVar Tuple Union Optional Type TypeVar None contained
+    syn keyword pythonType AbstractSet MutableSet Mapping MutableMapping Sequence MutableSequence ByteString Deque List contained
+    syn keyword pythonType Set FrozenSet MappingView KeysView ItemsView ValuesView Awaitable Coroutine AsyncIterable contained
+    syn keyword pythonType AsyncIterator ContextManager Dict DefaultDict Generator AsyncGenerator Text NamedTuple contained
+    syn keyword pythonType Iterable Iterator Reversible SupportsInt SupportsFloat SupportsAbs SupportsRound Container contained
+    syn keyword pythonType Hashable Sized Collection contained
+  endif
+endif
 
 syn match pythonStatement   "\<yield\>" display
 syn match pythonImport      "\<from\>" display

--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -190,7 +190,7 @@ endif
 " Decorators (new in Python 2.4)
 "
 
-syn match   pythonDecorator	"@" display nextgroup=pythonDottedName skipwhite
+syn match   pythonDecorator	"\(^\s*\)\@<=@" display nextgroup=pythonDottedName skipwhite
 if s:Python2Syntax()
   syn match   pythonDottedName "[a-zA-Z_][a-zA-Z0-9_]*\%(\.[a-zA-Z_][a-zA-Z0-9_]*\)*" display contained
 else

--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -415,7 +415,7 @@ if s:Enabled("g:python_highlight_builtin_objs")
   if s:Python2Syntax()
     syn keyword pythonBuiltinObj	None False True
   endif
-  syn keyword pythonBuiltinObj	Ellipsis NotImplemented
+  syn keyword pythonBuiltinObj	Ellipsis NotImplemented self cls
   syn keyword pythonBuiltinObj	__debug__ __doc__ __file__ __name__ __package__
 endif
 
@@ -425,28 +425,28 @@ endif
 
 if s:Enabled("g:python_highlight_builtin_funcs")
   if s:Python2Syntax()
-    syn keyword pythonBuiltinFunc	apply basestring buffer callable coerce
-    syn keyword pythonBuiltinFunc	execfile file help intern long raw_input
-    syn keyword pythonBuiltinFunc	reduce reload unichr unicode xrange
+    syn match pythonBuiltinFunc	'\v(\.)@<!\zs<(apply|basestring|buffer|callable|coerce)>'
+    syn match pythonBuiltinFunc	'\v(\.)@<!\zs<(execfile|file|help|intern|long|raw_input)>'
+    syn match pythonBuiltinFunc	'\v(\.)@<!\zs<(reduce|reload|unichr|unicode|xrange)>'
     if s:Enabled("g:python_print_as_function")
-      syn keyword pythonBuiltinFunc	print
+      syn match pythonBuiltinFunc	'\v(\.)@<!\zs<(print)>'
     endif
   else
-    syn keyword pythonBuiltinFunc	ascii exec memoryview print
+    syn match pythonBuiltinFunc	'\v(\.)@<!\zs<(ascii|exec|memoryview|print)>'
   endif
-  syn keyword pythonBuiltinFunc	__import__ abs all any
-  syn keyword pythonBuiltinFunc	bin bool bytearray bytes
-  syn keyword pythonBuiltinFunc	chr classmethod cmp compile complex
-  syn keyword pythonBuiltinFunc	delattr dict dir divmod enumerate eval
-  syn keyword pythonBuiltinFunc	filter float format frozenset getattr
-  syn keyword pythonBuiltinFunc	globals hasattr hash hex id
-  syn keyword pythonBuiltinFunc	input int isinstance
-  syn keyword pythonBuiltinFunc	issubclass iter len list locals map max
-  syn keyword pythonBuiltinFunc	min next object oct open ord
-  syn keyword pythonBuiltinFunc	pow property range
-  syn keyword pythonBuiltinFunc	repr reversed round set setattr
-  syn keyword pythonBuiltinFunc	slice sorted staticmethod str sum super tuple
-  syn keyword pythonBuiltinFunc	type vars zip
+  syn match pythonBuiltinFunc	'\v(\.)@<!\zs<(__import__|abs|all|any)>'
+  syn match pythonBuiltinFunc	'\v(\.)@<!\zs<(bin|bool|bytearray|bytes)>'
+  syn match pythonBuiltinFunc	'\v(\.)@<!\zs<(chr|classmethod|cmp|compile|complex)>'
+  syn match pythonBuiltinFunc	'\v(\.)@<!\zs<(delattr|dict|dir|divmod|enumerate|eval)>'
+  syn match pythonBuiltinFunc	'\v(\.)@<!\zs<(filter|float|format|frozenset|getattr)>'
+  syn match pythonBuiltinFunc	'\v(\.)@<!\zs<(globals|hasattr|hash|hex|id)>'
+  syn match pythonBuiltinFunc	'\v(\.)@<!\zs<(input|int|isinstance)>'
+  syn match pythonBuiltinFunc	'\v(\.)@<!\zs<(issubclass|iter|len|list|locals|map|max)>'
+  syn match pythonBuiltinFunc	'\v(\.)@<!\zs<(min|next|object|oct|open|ord)>'
+  syn match pythonBuiltinFunc	'\v(\.)@<!\zs<(pow|property|range)>'
+  syn match pythonBuiltinFunc	'\v(\.)@<!\zs<(repr|reversed|round|set|setattr)>'
+  syn match pythonBuiltinFunc	'\v(\.)@<!\zs<(slice|sorted|staticmethod|str|sum|super|tuple)>'
+  syn match pythonBuiltinFunc	'\v(\.)@<!\zs<(type|vars|zip)>'
 endif
 
 "

--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -176,9 +176,9 @@ if s:Python2Syntax()
   syn keyword pythonImport      as
   syn match   pythonFunction    "[a-zA-Z_][a-zA-Z0-9_]*" display contained
 else
-  syn keyword pythonStatement   as nonlocal None
+  syn keyword pythonStatement   as nonlocal
   syn match   pythonStatement   "\<yield\s\+from\>" display
-  syn keyword pythonBoolean     True False
+  syn keyword pythonBuiltinObj  None True False
   syn match   pythonFunction    "\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*" display contained
   syn keyword pythonStatement   await
   syn match   pythonStatement   "\<async\s\+def\>" nextgroup=pythonFunction skipwhite
@@ -399,8 +399,7 @@ syn match   pythonFloat		"\<\d\+\.\d*\%([eE][+-]\=\d\+\)\=[jJ]\=" display
 
 if s:Enabled("g:python_highlight_builtin_objs")
   if s:Python2Syntax()
-    syn keyword pythonBuiltinObj	None
-    syn keyword pythonBoolean		True False
+    syn keyword pythonBuiltinObj	None False True
   endif
   syn keyword pythonBuiltinObj	Ellipsis NotImplemented
   syn keyword pythonBuiltinObj	__debug__ __doc__ __file__ __name__ __package__

--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -154,7 +154,6 @@ syn keyword pythonStatement     break continue del
 syn keyword pythonStatement     exec return
 syn keyword pythonStatement     pass raise
 syn keyword pythonStatement     global assert
-syn keyword pythonStatement     lambda
 syn keyword pythonStatement     with
 syn keyword pythonStatement     def class nextgroup=pythonFunction skipwhite
 syn keyword pythonRepeat        for while
@@ -166,12 +165,15 @@ syn keyword pythonImport        import
 syn match   pythonIdentifier    "\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*" nextgroup=pythonFuncArgs,pythonTypeAnno display
 syn keyword pythonException     try except finally
 syn keyword pythonOperator      and in is not or
+syn match pythonLambdaExpr   "\<lambda[^:]*:"he=s+6 display nextgroup=@pythonExpression
+"syn keyword pythonStatement     lambda
 
 syn region pythonDictSetExpr matchgroup=pythonDictSetExpr start='{' end='}' contains=@pythonExpression
+syn region pythonListSliceExpr matchgroup=pythonListSliceExpr start='\[' end='\]' contains=@pythonExpression
 syn region pythonFuncArgs    matchgroup=pythonFuncArgs    start='(' end=')' contained contains=pythonTypeAnno,@pythonExpression
 
 syn match pythonTypeAnno ":\s*\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*"hs=s+1 display contained contains=pythonType nextgroup=pythonTypeArgs
-syn match pythonTypeAnnoReturn "->\s*\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*"hs=s+2,he=e-1 display contains=pythonType nextgroup=pythonTypeArgs
+syn match pythonTypeAnnoReturn "->\s*\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*" display contains=pythonType nextgroup=pythonTypeArgs
 syn region pythonTypeArgs matchgroup=pythonTypeArgs start='\[' end='\]' display contained contains=pythonType,pythonTypeArgs
 syn keyword pythonType Any AnyStr Callable ClassVar Tuple Union Optional Type TypeVar None contained
 syn keyword pythonType AbstractSet MutableSet Mapping MutableMapping Sequence MutableSequence ByteString Deque List contained
@@ -203,6 +205,8 @@ endif
 syn cluster pythonExpression contains=
             \ pythonFuncArgs,
             \ pythonDictSetExpr,
+            \ pythonListSliceExpr,
+            \ pythonLambdaExpr,
             \ pythonStatement,
             \ pythonRepeat,
             \ pythonConditional,
@@ -225,6 +229,9 @@ syn cluster pythonExpression contains=
 
 syn cluster pythonFExpression contains=
             \ pythonStatement,
+            \ pythonDictSetExpr,
+            \ pythonListSliceExpr,
+            \ pythonLambdaExpr,
             \ pythonRepeat,
             \ pythonConditional,
             \ pythonOperator,
@@ -559,6 +566,7 @@ if version >= 508 || !exists("did_python_syn_inits")
   endif
 
   HiLink pythonStatement        Statement
+  HiLink pythonLambdaExpr       Statement
   HiLink pythonImport           Include
   HiLink pythonFunction         Function
   HiLink pythonConditional      Conditional

--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -174,9 +174,9 @@ syn region pythonFuncArgs    matchgroup=pythonFuncArgs    start='(' end=')' cont
 
 if !s:Python2Syntax()
   if s:Enabled("g:python_highlight_type_annotations")
-    syn match pythonTypeAnno ":\s*\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*"hs=s+1 display contained contains=pythonType nextgroup=pythonTypeArgs
-    syn match pythonTypeAnnoReturn "->\s*\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*" display contains=pythonType nextgroup=pythonTypeArgs
-    syn region pythonTypeArgs matchgroup=pythonTypeArgs start='\[' end='\]' display contained contains=pythonType,pythonTypeArgs
+    syn match pythonTypeAnno @:\s*['"]\?\([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\([^[:cntrl:][:punct:][:space:]]\|_\)*['"]\?@hs=s+1 display contained contains=pythonType,pythonString nextgroup=pythonTypeArgs
+    syn match pythonTypeAnnoReturn @->\s*['"]\?\([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\([^[:cntrl:][:punct:][:space:]]\|_\)*['"]\?@ display contains=pythonType,pythonString nextgroup=pythonTypeArgs
+    syn region pythonTypeArgs matchgroup=pythonTypeArgs start='\[' end='\]' display contained contains=pythonType,pythonString,pythonTypeArgs
     syn keyword pythonType Any AnyStr Callable ClassVar Tuple Union Optional Type TypeVar None contained
     syn keyword pythonType AbstractSet MutableSet Mapping MutableMapping Sequence MutableSequence ByteString Deque List contained
     syn keyword pythonType Set FrozenSet MappingView KeysView ItemsView ValuesView Awaitable Coroutine AsyncIterable contained

--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -180,7 +180,7 @@ else
   syn match   pythonStatement   "\<yield\s\+from\>" display
   syn keyword pythonBuiltinObj  None True False
   syn match   pythonFunction    "\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*" display contained
-  syn keyword pythonStatement   await
+  syn keyword pythonStatement   await async
   syn match   pythonStatement   "\<async\s\+def\>" nextgroup=pythonFunction skipwhite
   syn match   pythonStatement   "\<async\s\+with\>" display
   syn match   pythonStatement   "\<async\s\+for\>" display

--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -186,6 +186,8 @@ else
   syn match   pythonStatement   "\<async\s\+for\>" display
 endif
 
+syn cluster pythonExpression contains=pythonStatement,pythonRepeat,pythonConditional,pythonOperator,pythonNumber,pythonHexNumber,pythonOctNumber,pythonBinNumber,pythonFloat,pythonString,pythonBytes,pythonBoolean,pythonBuiltinObj,pythonBuiltinFunc
+
 "
 " Decorators (new in Python 2.4)
 "
@@ -276,6 +278,11 @@ else
   syn region pythonString   start=+"+ skip=+\\\\\|\\"\|\\$+ excludenl end=+"+ end=+$+ keepend contains=pythonBytesEscape,pythonBytesEscapeError,pythonUniEscape,pythonUniEscapeError,@Spell
   syn region pythonString   start=+"""+ end=+"""+ keepend contains=pythonBytesEscape,pythonBytesEscapeError,pythonUniEscape,pythonUniEscapeError,pythonDocTest2,pythonSpaceError,@Spell
   syn region pythonString   start=+'''+ end=+'''+ keepend contains=pythonBytesEscape,pythonBytesEscapeError,pythonUniEscape,pythonUniEscapeError,pythonDocTest,pythonSpaceError,@Spell
+
+  syn region pythonFString   start=+[fF]'+ skip=+\\\\\|\\'\|\\$+ excludenl end=+'+ end=+$+ keepend contains=pythonBytesEscape,pythonBytesEscapeError,pythonUniEscape,pythonUniEscapeError,@Spell
+  syn region pythonFString   start=+[fF]"+ skip=+\\\\\|\\"\|\\$+ excludenl end=+"+ end=+$+ keepend contains=pythonBytesEscape,pythonBytesEscapeError,pythonUniEscape,pythonUniEscapeError,@Spell
+  syn region pythonFString   start=+[fF]"""+ end=+"""+ keepend contains=pythonBytesEscape,pythonBytesEscapeError,pythonUniEscape,pythonUniEscapeError,pythonDocTest2,pythonSpaceError,@Spell
+  syn region pythonFString   start=+[fF]'''+ end=+'''+ keepend contains=pythonBytesEscape,pythonBytesEscapeError,pythonUniEscape,pythonUniEscapeError,pythonDocTest,pythonSpaceError,@Spell
 endif
 
 if s:Python2Syntax()
@@ -326,8 +333,9 @@ if s:Enabled("g:python_highlight_string_format")
     syn match pythonStrFormat "{{\|}}" contained containedin=pythonString,pythonUniString,pythonUniRawString,pythonRawString
     syn match pythonStrFormat	"{\%(\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*\|\d\+\)\=\%(\.\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*\|\[\%(\d\+\|[^!:\}]\+\)\]\)*\%(![rsa]\)\=\%(:\%({\%(\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*\|\d\+\)}\|\%([^}]\=[<>=^]\)\=[ +-]\=#\=0\=\d*,\=\%(\.\d\+\)\=[bcdeEfFgGnosxX%]\=\)\=\)\=}" contained containedin=pythonString,pythonUniString,pythonUniRawString,pythonRawString
   else
-    syn match pythonStrFormat "{{\|}}" contained containedin=pythonString,pythonRawString
-    syn match pythonStrFormat	"{\%(\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*\|\d\+\)\=\%(\.\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*\|\[\%(\d\+\|[^!:\}]\+\)\]\)*\%(![rsa]\)\=\%(:\%({\%(\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*\|\d\+\)}\|\%([^}]\=[<>=^]\)\=[ +-]\=#\=0\=\d*,\=\%(\.\d\+\)\=[bcdeEfFgGnosxX%]\=\)\=\)\=}" contained containedin=pythonString,pythonRawString
+    syn match pythonStrFormat "{{\|}}" contained containedin=pythonString,pythonRawString,pythonFString
+    syn match pythonStrFormat "{\%(\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*\|\d\+\)\=\%(\.\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*\|\[\%(\d\+\|[^!:\}]\+\)\]\)*\%(![rsa]\)\=\%(:\%({\%(\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*\|\d\+\)}\|\%([^}]\=[<>=^]\)\=[ +-]\=#\=0\=\d*,\=\%(\.\d\+\)\=[bcdeEfFgGnosxX%]\=\)\=\)\=}" contained containedin=pythonString,pythonRawString
+    syn region pythonStrInterpRegion start="{"he=e+1,rs=e+1 end="\%(![rsa]\)\=\%(:\%({\%(\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*\|\d\+\)}\|\%([^}]\=[<>=^]\)\=[ +-]\=#\=0\=\d*,\=\%(\.\d\+\)\=[bcdeEfFgGnosxX%]\=\)\=\)\=}"hs=s-1,re=s-1 extend contained containedin=pythonFString contains=pythonStrInterpRegion,@pythonExpression
   endif
 endif
 
@@ -370,28 +378,34 @@ if s:Python2Syntax()
 
   syn match   pythonOctError	"\<0[oO]\=\o*[8-9]\d*[lL]\=\>" display
   syn match   pythonBinError	"\<0[bB][01]*[2-9]\d*[lL]\=\>" display
+
+  syn match   pythonFloat	"\.\d\+\%([eE][+-]\=\d\+\)\=[jJ]\=\>" display
+  syn match   pythonFloat	"\<\d\+[eE][+-]\=\d\+[jJ]\=\>" display
+  syn match   pythonFloat	"\<\d\+\.\d*\%([eE][+-]\=\d\+\)\=[jJ]\=" display
 else
   syn match   pythonHexError	"\<0[xX]\x*[g-zG-Z]\x*\>" display
   syn match   pythonOctError	"\<0[oO]\=\o*\D\+\d*\>" display
   syn match   pythonBinError	"\<0[bB][01]*\D\+\d*\>" display
 
-  syn match   pythonHexNumber	"\<0[xX]\x\+\>" display
-  syn match   pythonOctNumber "\<0[oO]\o\+\>" display
-  syn match   pythonBinNumber "\<0[bB][01]\+\>" display
+  syn match   pythonHexNumber	"\<0[xX][_0-9a-fA-F]*\x\>" display
+  syn match   pythonOctNumber "\<0[oO][_0-7]*\o\>" display
+  syn match   pythonBinNumber "\<0[bB][_01]*[01]\>" display
 
-  syn match   pythonNumberError	"\<\d\+\D\>" display
-  syn match   pythonNumberError	"\<0\d\+\>" display
+  syn match   pythonNumberError	"\<\d[_0-9]*\D\>" display
+  syn match   pythonNumberError	"\<0[_0-9]\+\>" display
+  syn match   pythonNumberError	"\<\%(_[_0-9]\+\|[_0-9]\+_\)\>" display
   syn match   pythonNumber	"\<\d\>" display
-  syn match   pythonNumber	"\<[1-9]\d\+\>" display
-  syn match   pythonNumber	"\<\d\+[jJ]\>" display
+  syn match   pythonNumber	"\<[1-9][_0-9]*\d\>" display
+  syn match   pythonNumber	"\<\d[jJ]\>" display
+  syn match   pythonNumber	"\<[1-9][_0-9]*\d[jJ]\>" display
 
   syn match   pythonOctError	"\<0[oO]\=\o*[8-9]\d*\>" display
   syn match   pythonBinError	"\<0[bB][01]*[2-9]\d*\>" display
-endif
 
-syn match   pythonFloat		"\.\d\+\%([eE][+-]\=\d\+\)\=[jJ]\=\>" display
-syn match   pythonFloat		"\<\d\+[eE][+-]\=\d\+[jJ]\=\>" display
-syn match   pythonFloat		"\<\d\+\.\d*\%([eE][+-]\=\d\+\)\=[jJ]\=" display
+  syn match   pythonFloat	"\.\d\%([_0-9]*\d\)\=\%([eE][+-]\=\d\%([_0-9]*\d\)\=\)\=[jJ]\=\>" display
+  syn match   pythonFloat	"\<\d\%([_0-9]*\d\)\=[eE][+-]\=\d\%([_0-9]*\d\)\=[jJ]\=\>" display
+  syn match   pythonFloat	"\<\d\%([_0-9]*\d\)\=\.\d\%([_0-9]*\d\)\=\%([eE][+-]\=\d\%([_0-9]*\d\)\=\)\=[jJ]\=" display
+endif
 
 "
 " Builtin objects and types
@@ -536,6 +550,8 @@ if version >= 508 || !exists("did_python_syn_inits")
     HiLink pythonBytesError         Error
     HiLink pythonBytesEscape        Special
     HiLink pythonBytesEscapeError   Error
+    HiLink pythonFString            String
+    HiLink pythonStrInterpRegion    Special
   endif
 
   HiLink pythonStrFormatting    Special

--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -163,8 +163,18 @@ syn keyword pythonConditional   if elif else
 " we provide a dummy group here to avoid crashing pyrex.vim.
 syn keyword pythonInclude       import
 syn keyword pythonImport        import
+syn match pythonIdentifier "\v[a-zA-Z_][a-zA-Z0-9_]*" nextgroup=FunctionParameters
 syn keyword pythonException     try except finally
 syn keyword pythonOperator      and in is not or
+
+" TODO: contain pythonTypeAnno in assignments and non-assigning variable type defs
+syn match pythonTypeAnno ":\s*[a-zA-Z0-9_\[\],\s]\+" display contained contains=pythonType
+syn keyword pythonType Any AnyStr Callable ClassVar Tuple Union Optional Type TypeVar contained
+syn keyword pythonType AbstractSet MutableSet Mapping MutableMapping Sequence MutableSequence ByteString Deque List contained
+syn keyword pythonType Set FrozenSet MappingView KeysView ItemsView ValuesView Awaitable Coroutine AsyncIterable contained
+syn keyword pythonType AsyncIterator ContextManager Dict DefaultDict Generator AsyncGenerator Text NamedTuple contained
+syn keyword pythonType Iterable Iterator Reversible SupportsInt SupportsFloat SupportsAbs SupportsRound Container contained
+syn keyword pythonType Hashable Sized Collection contained
 
 syn match pythonStatement   "\<yield\>" display
 syn match pythonImport      "\<from\>" display
@@ -179,12 +189,38 @@ else
   syn keyword pythonStatement   as nonlocal
   syn match   pythonStatement   "\<yield\s\+from\>" display
   syn keyword pythonBuiltinObj  None True False
-  syn match   pythonFunction    "\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*" display contained
+  syn match   pythonFunction    "[a-zA-Z_][a-zA-Z0-9_]*" nextgroup=FunctionParameters display contained
   syn keyword pythonStatement   await async
   syn match   pythonStatement   "\<async\s\+def\>" nextgroup=pythonFunction skipwhite
   syn match   pythonStatement   "\<async\s\+with\>" display
   syn match   pythonStatement   "\<async\s\+for\>" display
 endif
+
+syn region FunctionParameters start='(' end=')' display contains=
+            \ FunctionParameters,
+            \ pythonRepeat,
+            \ pythonConditional,
+            \ pythonComment,
+            \ pythonOperator,
+            \ pythonNumber,
+            \ pythonNumberError,
+            \ pythonFloat,
+            \ pythonHexNumber,
+            \ pythonStatement,
+            \ pythonOctNumber,
+            \ pythonString,
+            \ pythonRawString,
+            \ pythonUniString,
+            \ pythonExClass,
+            \ pythonUniRawString,
+            \ pythonNumber,
+            \ pythonRawString,
+            \ pythonBytes,
+            \ pythonBuiltinObj,
+            \ pythonNone,
+            \ pythonBuiltinFunc,
+            \ pythonTypeAnno,
+            \ pythonBoolean nextgroup=pythonRaiseFromStatement display contained
 
 syn cluster pythonExpression contains=pythonStatement,pythonRepeat,pythonConditional,pythonOperator,pythonNumber,pythonHexNumber,pythonOctNumber,pythonBinNumber,pythonFloat,pythonString,pythonBytes,pythonBoolean,pythonBuiltinObj,pythonBuiltinFunc
 
@@ -425,28 +461,28 @@ endif
 
 if s:Enabled("g:python_highlight_builtin_funcs")
   if s:Python2Syntax()
-    syn match pythonBuiltinFunc	'\v(\.)@<!\zs<(apply|basestring|buffer|callable|coerce)>'
-    syn match pythonBuiltinFunc	'\v(\.)@<!\zs<(execfile|file|help|intern|long|raw_input)>'
-    syn match pythonBuiltinFunc	'\v(\.)@<!\zs<(reduce|reload|unichr|unicode|xrange)>'
+    syn match pythonBuiltinFunc	'\v(\.)@<!\zs<(apply|basestring|buffer|callable|coerce)>\ze\(' nextgroup=FunctionParameters
+    syn match pythonBuiltinFunc	'\v(\.)@<!\zs<(execfile|file|help|intern|long|raw_input)>\ze\(' nextgroup=FunctionParameters
+    syn match pythonBuiltinFunc	'\v(\.)@<!\zs<(reduce|reload|unichr|unicode|xrange)>\ze\(' nextgroup=FunctionParameters
     if s:Enabled("g:python_print_as_function")
-      syn match pythonBuiltinFunc	'\v(\.)@<!\zs<(print)>'
+      syn match pythonBuiltinFunc	'\v(\.)@<!\zs<(print)>\ze\(' nextgroup=FunctionParameters
     endif
   else
-    syn match pythonBuiltinFunc	'\v(\.)@<!\zs<(ascii|exec|memoryview|print)>'
+    syn match pythonBuiltinFunc	'\v(\.)@<!\zs<(ascii|exec|memoryview|print)\ze\(>' nextgroup=FunctionParameters
   endif
-  syn match pythonBuiltinFunc	'\v(\.)@<!\zs<(__import__|abs|all|any)>'
-  syn match pythonBuiltinFunc	'\v(\.)@<!\zs<(bin|bool|bytearray|bytes)>'
-  syn match pythonBuiltinFunc	'\v(\.)@<!\zs<(chr|classmethod|cmp|compile|complex)>'
-  syn match pythonBuiltinFunc	'\v(\.)@<!\zs<(delattr|dict|dir|divmod|enumerate|eval)>'
-  syn match pythonBuiltinFunc	'\v(\.)@<!\zs<(filter|float|format|frozenset|getattr)>'
-  syn match pythonBuiltinFunc	'\v(\.)@<!\zs<(globals|hasattr|hash|hex|id)>'
-  syn match pythonBuiltinFunc	'\v(\.)@<!\zs<(input|int|isinstance)>'
-  syn match pythonBuiltinFunc	'\v(\.)@<!\zs<(issubclass|iter|len|list|locals|map|max)>'
-  syn match pythonBuiltinFunc	'\v(\.)@<!\zs<(min|next|object|oct|open|ord)>'
-  syn match pythonBuiltinFunc	'\v(\.)@<!\zs<(pow|property|range)>'
-  syn match pythonBuiltinFunc	'\v(\.)@<!\zs<(repr|reversed|round|set|setattr)>'
-  syn match pythonBuiltinFunc	'\v(\.)@<!\zs<(slice|sorted|staticmethod|str|sum|super|tuple)>'
-  syn match pythonBuiltinFunc	'\v(\.)@<!\zs<(type|vars|zip)>'
+  syn match pythonBuiltinFunc	'\v(\.)@<!\zs<(__import__|abs|all|any)>\ze\(' nextgroup=FunctionParameters
+  syn match pythonBuiltinFunc	'\v(\.)@<!\zs<(bin|bool|bytearray|bytes)>\ze\(' nextgroup=FunctionParameters
+  syn match pythonBuiltinFunc	'\v(\.)@<!\zs<(chr|classmethod|cmp|compile|complex)>\ze\(' nextgroup=FunctionParameters
+  syn match pythonBuiltinFunc	'\v(\.)@<!\zs<(delattr|dict|dir|divmod|enumerate|eval)>\ze\(' nextgroup=FunctionParameters
+  syn match pythonBuiltinFunc	'\v(\.)@<!\zs<(filter|float|format|frozenset|getattr)>\ze\(' nextgroup=FunctionParameters
+  syn match pythonBuiltinFunc	'\v(\.)@<!\zs<(globals|hasattr|hash|hex|id)>\ze\(' nextgroup=FunctionParameters
+  syn match pythonBuiltinFunc	'\v(\.)@<!\zs<(input|int|isinstance)>\ze\(' nextgroup=FunctionParameters
+  syn match pythonBuiltinFunc	'\v(\.)@<!\zs<(issubclass|iter|len|list|locals|map|max)>\ze\(' nextgroup=FunctionParameters
+  syn match pythonBuiltinFunc	'\v(\.)@<!\zs<(min|next|object|oct|open|ord)>\ze\(' nextgroup=FunctionParameters
+  syn match pythonBuiltinFunc	'\v(\.)@<!\zs<(pow|property|range)>\ze\(' nextgroup=FunctionParameters
+  syn match pythonBuiltinFunc	'\v(\.)@<!\zs<(repr|reversed|round|set|setattr)>\ze\(' nextgroup=FunctionParameters
+  syn match pythonBuiltinFunc	'\v(\.)@<!\zs<(slice|sorted|staticmethod|str|sum|super|tuple)>\ze\(' nextgroup=FunctionParameters
+  syn match pythonBuiltinFunc	'\v(\.)@<!\zs<(type|vars|zip)>\ze\(' nextgroup=FunctionParameters
 endif
 
 "
@@ -455,39 +491,39 @@ endif
 
 if s:Enabled("g:python_highlight_exceptions")
   if s:Python2Syntax()
-    syn keyword pythonExClass	StandardError
+    syn keyword pythonExClass	StandardError nextgroup=FunctionParameters
   else
-    syn keyword pythonExClass	BlockingIOError ChildProcessError
-    syn keyword pythonExClass	ConnectionError BrokenPipeError
-    syn keyword pythonExClass	ConnectionAbortedError ConnectionRefusedError
-    syn keyword pythonExClass	ConnectionResetError FileExistsError
-    syn keyword pythonExClass	FileNotFoundError InterruptedError
-    syn keyword pythonExClass	IsADirectoryError NotADirectoryError
-    syn keyword pythonExClass	PermissionError ProcessLookupError TimeoutError
+    syn keyword pythonExClass	BlockingIOError ChildProcessError nextgroup=FunctionParameters
+    syn keyword pythonExClass	ConnectionError BrokenPipeError nextgroup=FunctionParameters
+    syn keyword pythonExClass	ConnectionAbortedError ConnectionRefusedError nextgroup=FunctionParameters
+    syn keyword pythonExClass	ConnectionResetError FileExistsError nextgroup=FunctionParameters
+    syn keyword pythonExClass	FileNotFoundError InterruptedError nextgroup=FunctionParameters
+    syn keyword pythonExClass	IsADirectoryError NotADirectoryError nextgroup=FunctionParameters
+    syn keyword pythonExClass	PermissionError ProcessLookupError TimeoutError nextgroup=FunctionParameters
 
-    syn keyword pythonExClass	ResourceWarning
+    syn keyword pythonExClass	ResourceWarning nextgroup=FunctionParameters
   endif
-  syn keyword pythonExClass	BaseException
-  syn keyword pythonExClass	Exception ArithmeticError
-  syn keyword pythonExClass	LookupError EnvironmentError
+  syn keyword pythonExClass	BaseException nextgroup=FunctionParameters
+  syn keyword pythonExClass	Exception ArithmeticError nextgroup=FunctionParameters
+  syn keyword pythonExClass	LookupError EnvironmentError nextgroup=FunctionParameters
 
-  syn keyword pythonExClass	AssertionError AttributeError BufferError EOFError
-  syn keyword pythonExClass	FloatingPointError GeneratorExit IOError
-  syn keyword pythonExClass	ImportError IndexError KeyError
-  syn keyword pythonExClass	KeyboardInterrupt MemoryError NameError
-  syn keyword pythonExClass	NotImplementedError OSError OverflowError
-  syn keyword pythonExClass	ReferenceError RuntimeError StopIteration
-  syn keyword pythonExClass	SyntaxError IndentationError TabError
-  syn keyword pythonExClass	SystemError SystemExit TypeError
-  syn keyword pythonExClass	UnboundLocalError UnicodeError
-  syn keyword pythonExClass	UnicodeEncodeError UnicodeDecodeError
-  syn keyword pythonExClass	UnicodeTranslateError ValueError VMSError
-  syn keyword pythonExClass	WindowsError ZeroDivisionError
+  syn keyword pythonExClass	AssertionError AttributeError BufferError EOFError nextgroup=FunctionParameters
+  syn keyword pythonExClass	FloatingPointError GeneratorExit IOError nextgroup=FunctionParameters
+  syn keyword pythonExClass	ImportError IndexError KeyError nextgroup=FunctionParameters
+  syn keyword pythonExClass	KeyboardInterrupt MemoryError NameError nextgroup=FunctionParameters
+  syn keyword pythonExClass	NotImplementedError OSError OverflowError nextgroup=FunctionParameters
+  syn keyword pythonExClass	ReferenceError RuntimeError StopIteration nextgroup=FunctionParameters
+  syn keyword pythonExClass	SyntaxError IndentationError TabError nextgroup=FunctionParameters
+  syn keyword pythonExClass	SystemError SystemExit TypeError nextgroup=FunctionParameters
+  syn keyword pythonExClass	UnboundLocalError UnicodeError nextgroup=FunctionParameters
+  syn keyword pythonExClass	UnicodeEncodeError UnicodeDecodeError nextgroup=FunctionParameters
+  syn keyword pythonExClass	UnicodeTranslateError ValueError VMSError nextgroup=FunctionParameters
+  syn keyword pythonExClass	WindowsError ZeroDivisionError nextgroup=FunctionParameters
 
-  syn keyword pythonExClass	Warning UserWarning BytesWarning DeprecationWarning
-  syn keyword pythonExClass	PendingDepricationWarning SyntaxWarning
-  syn keyword pythonExClass	RuntimeWarning FutureWarning
-  syn keyword pythonExClass	ImportWarning UnicodeWarning
+  syn keyword pythonExClass	Warning UserWarning BytesWarning DeprecationWarning nextgroup=FunctionParameters
+  syn keyword pythonExClass	PendingDepricationWarning SyntaxWarning nextgroup=FunctionParameters
+  syn keyword pythonExClass	RuntimeWarning FutureWarning nextgroup=FunctionParameters
+  syn keyword pythonExClass	ImportWarning UnicodeWarning nextgroup=FunctionParameters
 endif
 
 if s:Enabled("g:python_slow_sync")
@@ -576,6 +612,9 @@ if version >= 508 || !exists("did_python_syn_inits")
   HiLink pythonBuiltinFunc      Function
 
   HiLink pythonExClass          Structure
+
+  HiLink pythonTypeAnno         Optional
+  HiLink pythonType             Special
 
   delcommand HiLink
 endif

--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -493,7 +493,7 @@ if s:Enabled("g:python_highlight_builtin_funcs")
       syn match pythonBuiltinFunc       '\v(\.)@<!\zs<(print)>\ze\(' nextgroup=pythonFuncArgs
     endif
   else
-    syn match pythonBuiltinFunc '\v(\.)@<!\zs<(ascii|exec|memoryview|print)\ze\(>' nextgroup=pythonFuncArgs
+    syn match pythonBuiltinFunc '\v(\.)@<!\zs<(ascii|exec|memoryview|print)\ze\(' nextgroup=pythonFuncArgs
   endif
   syn match pythonBuiltinFunc   '\v(\.)@<!\zs<(__import__|abs|all|any)>\ze\(' nextgroup=pythonFuncArgs
   syn match pythonBuiltinFunc   '\v(\.)@<!\zs<(bin|bool|bytearray|bytes)>\ze\(' nextgroup=pythonFuncArgs

--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -171,7 +171,7 @@ syn region pythonDictSetExpr matchgroup=pythonDictSetExpr start='{' end='}' cont
 syn region pythonFuncArgs    matchgroup=pythonFuncArgs    start='(' end=')' contained contains=pythonTypeAnno,@pythonExpression
 
 syn match pythonTypeAnno ":\s*\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*"hs=s+1 display contained contains=pythonType nextgroup=pythonTypeArgs
-syn match pythonTypeAnnoReturn "->\s*\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*:"hs=s+2,he=e-1 display contains=pythonType nextgroup=pythonTypeArgs
+syn match pythonTypeAnnoReturn "->\s*\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*"hs=s+2,he=e-1 display contains=pythonType nextgroup=pythonTypeArgs
 syn region pythonTypeArgs matchgroup=pythonTypeArgs start='\[' end='\]' display contained contains=pythonType,pythonTypeArgs
 syn keyword pythonType Any AnyStr Callable ClassVar Tuple Union Optional Type TypeVar None contained
 syn keyword pythonType AbstractSet MutableSet Mapping MutableMapping Sequence MutableSequence ByteString Deque List contained

--- a/test.py
+++ b/test.py
@@ -8,8 +8,11 @@
 
 # Keywords.
 
-with break continue del exec return pass print raise global assert lambda yield
+with break continue del exec return pass print raise global assert yield
 for while if elif else import from as try except finally and in is not or
+
+lambda: a + 1
+lambda x, y: x + y
 
 yield from
 
@@ -29,6 +32,7 @@ def myfunc(a: str, something_other,
            b: Callable[[str, str], int]) -> Any:
     myval: float
     mygood: Optional[int, Any] = b('wow', 'oops')
+    myarr: Sequence[int] = origarr[aa:bb]
     mykey = a
     wow = {
         mykey: this_should_not_be_type_anno[Any],
@@ -39,6 +43,9 @@ def myfunc(a: str, something_other,
         'b': 'zxcb',
         mykey: this_should_not_be_type_anno[Any],
     }, b=mydata['a'])
+    vanilla_lambda = lambda x, y: myval + 1.0
+    call_with_lambda(lambda x, y: myval + 1.0)
+    call_with_slice(mydata[range_start:range_end])
 
 
 # Builtin objects.

--- a/test.py
+++ b/test.py
@@ -67,7 +67,7 @@ RuntimeWarning FutureWarning ImportWarning UnicodeWarning
 # Erroneous numbers
 
 077 100L 0xfffffffL 0L 08 0xk 0x 0b102 0o78 0o123LaB
-0_ 0_1 _0 0_x1f 0x1f_ 0_b77 0b77_ ._2 .2_ 1_j
+0_ 0_1 0_x1f 0x1f_ 0_b77 0b77_ .2_ 1_j
 
 # Strings
 

--- a/test.py
+++ b/test.py
@@ -29,7 +29,8 @@ async for
 # Type annotations
 
 def myfunc(a: str, something_other,
-           b: Callable[[str, str], int]) -> 'runtime_resolved_type':
+           b: Callable[[str, str], int],
+           c: mypkg.MyType) -> 'runtime_resolved_type':
     myval: float
     mygood: Optional[int, Any] = b('wow', 'oops')
     myarr: Sequence[int] = origarr[aa:bb] + (lambda: x)()

--- a/test.py
+++ b/test.py
@@ -32,7 +32,7 @@ def myfunc(a: str, something_other,
            b: Callable[[str, str], int]) -> Any:
     myval: float
     mygood: Optional[int, Any] = b('wow', 'oops')
-    myarr: Sequence[int] = origarr[aa:bb]
+    myarr: Sequence[int] = origarr[aa:bb] + (lambda: x)()
     mykey = a
     wow = {
         mykey: this_should_not_be_type_anno[Any],

--- a/test.py
+++ b/test.py
@@ -61,11 +61,13 @@ RuntimeWarning FutureWarning ImportWarning UnicodeWarning
 
 # Numbers
 
-0 1 2 9 10 0x1f .3 12.34 0j 0j 34.2E-3 0b10 0o77 1023434 0x0
+0 1 2 9 10 0x1f .3 12.34 0j 124j 34.2E-3 0b10 0o77 1023434 0x0
+1_1 1_1.2_2 1_2j 0x_1f 0x1_f 34_56e-3 34_56e+3_1 0o7_7
 
 # Erroneous numbers
 
-077 100L 0xfffffffL 0L 08 0xk 0x  0b102 0o78 0o123LaB
+077 100L 0xfffffffL 0L 08 0xk 0x 0b102 0o78 0o123LaB
+0_ 0_1 _0 0_x1f 0x1f_ 0_b77 0b77_ ._2 .2_ 1_j
 
 # Strings
 
@@ -102,6 +104,10 @@ b"{0.name!r:b} {0[n]} {name!s:  } {{test}} {{}} {} {.__len__:s}"
 
 "${test} ${test ${test}aname $$$ $test+nope"
 b"${test} ${test ${test}aname $$$ $test+nope"
+
+f"{var}...{arr[123]} normal {var['{'] // 0xff} \"xzcb\" 'xzcb' {var['}'] + 1} text"
+f"{expr1 if True or False else expr2} wow {','.join(c.lower() for c in 'asdf')}"
+f"hello {expr:.2f} yes {(lambda: 0b1)():#03x} lol {var!r}"
 
 # Doctests.
 

--- a/test.py
+++ b/test.py
@@ -29,7 +29,7 @@ async for
 # Type annotations
 
 def myfunc(a: str, something_other,
-           b: Callable[[str, str], int]) -> Any:
+           b: Callable[[str, str], int]) -> 'runtime_resolved_type':
     myval: float
     mygood: Optional[int, Any] = b('wow', 'oops')
     myarr: Sequence[int] = origarr[aa:bb] + (lambda: x)()

--- a/test.py
+++ b/test.py
@@ -23,19 +23,43 @@ async def Test
 async with
 async for
 
+# Type annotations
+
+def myfunc(a: str, something_other,
+           b: Callable[[str, str], int]) -> Any:
+    myval: float
+    mygood: Optional[int, Any] = b('wow', 'oops')
+    mykey = a
+    wow = {
+        mykey: this_should_not_be_type_anno[Any],
+        'b': some_data,
+    }
+    call_with_dict(a={
+        'a': asdf,
+        'b': 'zxcb',
+        mykey: this_should_not_be_type_anno[Any],
+    }, b=mydata['a'])
+
+
 # Builtin objects.
 
 True False Ellipsis None NotImplemented
 
 # Builtin function and types.
 
-__import__ abs all any apply basestring bool buffer callable chr classmethod
-cmp coerce compile complex delattr dict dir divmod enumerate eval execfile file
-filter float frozenset getattr globals hasattr hash help hex id input int
-intern isinstance issubclass iter len list locals long map max min object oct
-open ord pow property range raw_input reduce reload repr reversed round set
-setattr slice sorted staticmethod str sum super tuple type unichr unicode vars
-xrange zip
+__import__() abs() all() any() apply() basestring() bool() buffer() callable() chr() classmethod()
+cmp() coerce() compile() complex() delattr() dict() dir() divmod() enumerate() eval() execfile() file()
+filter() float() frozenset() getattr() globals() hasattr() hash() help() hex() id() input() int()
+intern() isinstance() issubclass() iter() len() list() locals() long() map() max() min() object() oct()
+open() ord() pow() property() range() raw_input() reduce() reload() repr() reversed() round() set()
+setattr() slice() sorted() staticmethod() str() sum() super() tuple() type() unichr() unicode() vars()
+xrange() zip()
+
+when_we_dont_call = a.float
+float = when_we_dont_call
+
+when_we_call = float(x)
+when_we_call = min(a, b)
 
 # Builtin exceptions and warnings.
 


### PR DESCRIPTION
PR for #58 and #59.
Finally I figured out how to "embed" other syntax inside a region using `syn cluster`.
Python keywords, numbers, booleans, and builtins are highlighted inside f-string braced regions.
I tried to prevent the content inside braces from being highlighted as "Special" while keeping the braces and format string highlighted, but could not separate them. Still, I think this version much improves readability.

![image](https://cloud.githubusercontent.com/assets/555156/20627786/b24762fc-b365-11e6-947a-e843e1f3f3f3.png)
![image](https://cloud.githubusercontent.com/assets/555156/20627788/b7db2be0-b365-11e6-9c3e-d3ae750434c4.png)

Comments, optimizations, and fixes are welcome.