### PR TITLE
Remove all trailing slashes from pythonBytesEscape

### DIFF
--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -255,7 +255,6 @@ syn match pythonBytesEscape       "\\\o\o\=\o\=" display contained
 syn match pythonBytesEscapeError  "\\\o\{,2}[89]" display contained
 syn match pythonBytesEscape       "\\x\x\{2}" display contained
 syn match pythonBytesEscapeError  "\\x\x\=\X" display contained
-syn match pythonBytesEscape       "\\$"
 
 syn match pythonUniEscape         "\\u\x\{4}" display contained
 syn match pythonUniEscapeError    "\\u\x\{,3}\X" display contained


### PR DESCRIPTION
Considering trailing slashes a string escape seems to have been removed for other string types when merging Python 2 and 3 syntaxes.

I'm currently working on an MR for hynek/vim-python-pep8-indent to properly ignore braces in byte strings https://github.com/hynek/vim-python-pep8-indent/pull/68. Unfortunately python-syntax marking all trailing \ as a type of string is causing problems with correct indenting.

Outside of that, I don't think all trailing \ should be considered pythonBytesEscape when they are not inside a pythonBytes.