### PR TITLE
Added support for match and case keywords introduced in python 3.10

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,8 @@
+Revision 3.10 (2022-01-09):
+
+   - Add support for 'match' and 'case' keywords introduced in
+     Python 3.10. Patch by Joaquin Bogado
+
 Revision 3.6.0 (2015-11-XX):
 
     - Fix 'async def' highlighting. Patch by Joongi Kim

--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -31,6 +31,7 @@
 "   Elizabeth Myers
 "   Ihor Gorobets
 "   Jeroen Ruigrok van der Werven
+"   Joaquin Bogado
 "   John Eikenberry
 "   Joongi Kim
 "   Marc Weber
@@ -159,6 +160,7 @@ syn keyword pythonStatement     with
 syn keyword pythonStatement     def class nextgroup=pythonFunction skipwhite
 syn keyword pythonRepeat        for while
 syn keyword pythonConditional   if elif else
+syn keyword pythonConditional   match case
 " The standard pyrex.vim unconditionally removes the pythonInclude group, so
 " we provide a dummy group here to avoid crashing pyrex.vim.
 syn keyword pythonInclude       import


### PR DESCRIPTION
Revision 3.10 (2022-01-09):

   - Add support for 'match' and 'case' keywords introduced in
     Python 3.10. Patch by Joaquin Bogado.